### PR TITLE
Use something other than APP_ID for botId

### DIFF
--- a/src/adapters/supabase/helpers/user.ts
+++ b/src/adapters/supabase/helpers/user.ts
@@ -17,10 +17,8 @@ export class User extends Super {
     if ((error && !data) || !data.wallets?.address) {
       this.context.logger.error("No wallet address found", { userId, issueNumber });
       if (this.context.config.startRequiresWallet) {
-        await addCommentToIssue(this.context, this.context.config.emptyWalletText);
+        await addCommentToIssue(this.context, this.context.logger.error(this.context.config.emptyWalletText, { userId, issueNumber }).logMessage.diff);
         throw new Error("No wallet address found");
-      } else {
-        await addCommentToIssue(this.context, this.context.config.emptyWalletText);
       }
     } else {
       this.context.logger.info("Successfully fetched wallet", { userId, address: data.wallets?.address });

--- a/src/handlers/shared/start.ts
+++ b/src/handlers/shared/start.ts
@@ -141,12 +141,11 @@ async function handleTaskLimitChecks(username: string, context: Context, maxConc
   // check for max and enforce max
 
   if (Math.abs(assignedIssues.length - openedPullRequests.length) >= maxConcurrentTasks) {
-    const log = logger.error(username === sender ? "You have reached your max task limit" : `${username} has reached their max task limit`, {
+    logger.error(username === sender ? "You have reached your max task limit" : `${username} has reached their max task limit`, {
       assignedIssues: assignedIssues.length,
       openedPullRequests: openedPullRequests.length,
       maxConcurrentTasks,
     });
-    await addCommentToIssue(context, log?.logMessage.diff as string);
     return false;
   }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -50,7 +50,7 @@ export default {
       const decodedEnv = Value.Decode(envConfigValidator.schema, env);
       webhookPayload.env = decodedEnv;
       webhookPayload.settings = settings;
-      await startStopTask(webhookPayload, env);
+      await startStopTask(webhookPayload, decodedEnv);
       return new Response(JSON.stringify("OK"), { status: 200, headers: { "content-type": "application/json" } });
     } catch (error) {
       return handleUncaughtError(error);


### PR DESCRIPTION
Resolves #34 

- `APP_ID` cannot be used to ID the bot
- remove two comment postings
- pass `decodedEnv`
