### PR TITLE
fix: added test for start with carriage returns

### DIFF
--- a/src/handlers/user-start-stop.ts
+++ b/src/handlers/user-start-stop.ts
@@ -11,7 +11,7 @@ export async function userStartStop(context: Context): Promise<Result> {
   }
   const { payload } = context;
   const { issue, comment, sender, repository } = payload;
-  const slashCommand = comment.body.split(" ")[0].replace("/", "");
+  const slashCommand = comment.body.trim().split(" ")[0].replace("/", "");
   const teamMates = comment.body
     .split("@")
     .slice(1)

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -89,7 +89,7 @@ describe("User start/stop", () => {
 
     const { content } = await userStartStop(context);
 
-    expect(content).toEqual(SUCCESS_MESSAGE);
+    expect(content).toEqual("Task unassigned successfully");
   });
 
   test("Stopping an issue should close the author's linked PR", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -72,7 +72,7 @@ describe("User start/stop", () => {
 
     const { content } = await userStartStop(context);
 
-    expect(content).toEqual("Task assigned successfully");
+    expect(content).toEqual(SUCCESS_MESSAGE);
 
     const issue2 = db.issue.findFirst({ where: { id: { equals: 1 } } }) as unknown as Issue;
     expect(issue2.assignees).toHaveLength(2);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -27,6 +27,8 @@ afterEach(() => {
 });
 afterAll(() => server.close());
 
+const SUCCESS_MESSAGE = "Task assigned successfully";
+
 describe("User start/stop", () => {
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -44,7 +46,20 @@ describe("User start/stop", () => {
 
     const { content } = await userStartStop(context);
 
-    expect(content).toEqual("Task assigned successfully");
+    expect(content).toEqual(SUCCESS_MESSAGE);
+  });
+
+  test("User can start an issue with trimmed command", async () => {
+    const issue = db.issue.findFirst({ where: { id: { equals: 1 } } }) as unknown as Issue;
+    const sender = db.users.findFirst({ where: { id: { equals: 1 } } }) as unknown as PayloadSender;
+
+    const context = createContext(issue, sender, "\n\n/start\n") as Context<"issue_comment.created">;
+
+    context.adapters = createAdapters(getSupabase(), context);
+
+    const { content } = await userStartStop(context);
+
+    expect(content).toEqual(SUCCESS_MESSAGE);
   });
 
   test("User can start an issue with teammates", async () => {
@@ -74,7 +89,7 @@ describe("User start/stop", () => {
 
     const { content } = await userStartStop(context);
 
-    expect(content).toEqual("Task unassigned successfully");
+    expect(content).toEqual(SUCCESS_MESSAGE);
   });
 
   test("Stopping an issue should close the author's linked PR", async () => {


### PR DESCRIPTION
Resolves https://github.com/ubiquity/ubiquibot-kernel/issues/105
QA: https://github.com/Meniole/command-start-stop/issues/16

<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
