### PR TITLE
Render warning with new table design

### DIFF
--- a/src/handlers/shared/table.ts
+++ b/src/handlers/shared/table.ts
@@ -5,7 +5,7 @@ export function assignTableComment({ taskDeadline, registeredWallet, isTaskStale
     elements.push(
       "<tr>",
       "<td>Warning!</td>",
-      `<td><This task was created over ${daysElapsedSinceTaskCreation} days ago. Please confirm that this issue specification is accurate before starting.</td>`,
+      `<td>This task was created over ${daysElapsedSinceTaskCreation} days ago. Please confirm that this issue specification is accurate before starting.</td>`,
       "</tr>"
     );
   }


### PR DESCRIPTION
Fixes the new table design not rendering warnings.

See this [comment](https://github.com/ubiquity/pay.ubq.fi/issues/281#issuecomment-2361917471)

![image](https://github.com/user-attachments/assets/b7b8e60a-871e-411f-bbd5-88ebf1752307)
